### PR TITLE
Open scanner on launch and log barcode data

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,41 @@
+import 'package:flutter/material.dart';
+import 'package:mobile_scanner/mobile_scanner.dart';
+
+import 'scan_handler.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      debugShowCheckedModeBanner: false,
+      home: ScannerScreen(),
+    );
+  }
+}
+
+class ScannerScreen extends StatelessWidget {
+  const ScannerScreen({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: MobileScanner(
+        onDetect: (BarcodeCapture capture) {
+          for (final barcode in capture.barcodes) {
+            final String? raw = barcode.rawValue;
+            if (raw != null) {
+              handleScan(raw);
+            }
+          }
+        },
+      ),
+    );
+  }
+}
+

--- a/lib/scan_handler.dart
+++ b/lib/scan_handler.dart
@@ -1,0 +1,6 @@
+void handleScan(String code) {
+  // Print the scanned barcode to the console.
+  // ignore: avoid_print
+  print('Scanned code: $code');
+}
+

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter:
     sdk: flutter
   cupertino_icons: ^1.0.8
+  mobile_scanner: ^3.0.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- display mobile scanner immediately on app start
- log detected barcode using a handler function
- declare `mobile_scanner` dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter test` *(fails: command not found)*
- `dart format .` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b8249e330083239139059152d2babb