### PR TITLE
Beep and open scanned QR code in browser

### DIFF
--- a/lib/scan_handler.dart
+++ b/lib/scan_handler.dart
@@ -1,6 +1,12 @@
-void handleScan(String code) {
-  // Print the scanned barcode to the console.
-  // ignore: avoid_print
-  print('Scanned code: $code');
+import 'package:flutter/services.dart';
+import 'package:url_launcher/url_launcher.dart';
+
+Future<void> handleScan(String code) async {
+  await SystemSound.play(SystemSoundType.alert);
+  final Uri uri = Uri.parse('https://ya.ru/$code');
+  if (!await launchUrl(uri, mode: LaunchMode.externalApplication)) {
+    // ignore: avoid_print
+    print('Could not launch $uri');
+  }
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
     sdk: flutter
   cupertino_icons: ^1.0.8
   mobile_scanner: ^3.0.0
+  url_launcher: ^6.2.4
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- beep when a barcode is scanned and launch ya.ru/<code>
- add url_launcher dependency

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b82bf340888323ad28ddca8911336d